### PR TITLE
fix #33 support up-to-date check

### DIFF
--- a/src/main/java/com/github/erizo/gradle/JcstressPlugin.java
+++ b/src/main/java/com/github/erizo/gradle/JcstressPlugin.java
@@ -214,14 +214,21 @@ public class JcstressPlugin implements Plugin<Project> {
         jcstressTask.setDescription("Runs jcstress benchmarks.");
         jcstressTask.setJvmArgs(Arrays.asList("-XX:+UnlockDiagnosticVMOptions", "-XX:+WhiteBoxAPI", "-XX:-RestrictContended", "-Duser.language=" + jcstressPluginExtension.getLanguage()));
         jcstressTask.setClasspath(jcstressConfiguration.plus(project.getConfigurations().getByName(JCSTRESS_SOURCESET_NAME + "RuntimeClasspath").plus(mainRuntimeClasspath)));
-        jcstressTask.doFirst(task1 -> getAndCreateDirectory(project.getBuildDir(), "tmp", "jcstress"));
+        jcstressTask.doFirst(new Action<Task>() {
+            @Override
+            public void execute(Task task1) {
+                getAndCreateDirectory(project.getBuildDir(), "tmp", "jcstress");
+            }
+        });
 
         project.afterEvaluate(project -> {
             if (jcstressPluginExtension.getReportDir() == null) {
                 jcstressPluginExtension.setReportDir(getAndCreateDirectory(project.getBuildDir(), "reports", "jcstress").getAbsolutePath());
             }
-
             jcstressTask.args(jcstressPluginExtension.buildArgs());
+
+            jcstressTask.reportsDirectory = new File(jcstressPluginExtension.getReportDir());
+
             jcstressTask.setProperty("classpath", jcstressTask.getClasspath().plus(project.files(jcstressJarTask.getArchiveFile())));
             filterConfiguration(jcstressConfiguration, "jcstress-core");
             if (jcstressPluginExtension.getIncludeTests()) {
@@ -232,7 +239,12 @@ public class JcstressPlugin implements Plugin<Project> {
             jcstressTask.setWorkingDir(path);
         });
 
-        jcstressTask.doFirst(task1 -> jcstressTask.args(jcstressTask.jcstressArgs()));
+        jcstressTask.doFirst(new Action<Task>() {
+            @Override
+            public void execute(Task task1) {
+                jcstressTask.args(jcstressTask.jcstressArgs());
+            }
+        });
 
         return jcstressTask;
     }

--- a/src/main/java/com/github/erizo/gradle/JcstressTask.java
+++ b/src/main/java/com/github/erizo/gradle/JcstressTask.java
@@ -1,16 +1,20 @@
 package com.github.erizo.gradle;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.options.Option;
 
 public class JcstressTask extends JavaExec {
 
     private String jcstressTestName;
+
+    File reportsDirectory;
 
     @Option(option = "tests", description = "JCstress tests to execute.")
     public void setJcstressTestName(String jcstressTestName) {
@@ -21,6 +25,11 @@ public class JcstressTask extends JavaExec {
     @Optional
     public String getJcstressTestName() {
         return jcstressTestName;
+    }
+
+    @OutputDirectory
+    public File getReportsDirectory() {
+        return reportsDirectory;
     }
 
     public List<String> jcstressArgs() {


### PR DESCRIPTION
This adds an outputproperty made of the reports directory.
Given that the JcstressTask inherits from the JavaExec task, input
properties (which determine what needs to be looked at to decide if
task is up-to-date) are already supported and contain
- the java exec classpath (which itselfs changes when user tests change)
- the java exec args